### PR TITLE
Add gnu source

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,3 +1,4 @@
+(source gnu)
 (source melpa)
 
 (package-file "snapshot-timemachine-rsnapshot.el")


### PR DESCRIPTION
seq is hosted at gnu elpa.
